### PR TITLE
APP-2053 - Add counterParty in Transaction payload

### DIFF
--- a/src/DTO/CounterPartyDTO.php
+++ b/src/DTO/CounterPartyDTO.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Ofload\Butn\DTO;
+
+use JsonSerializable;
+
+class CounterPartyDTO implements JsonSerializable
+{
+    private ?string $name = null;
+    private string $abn;
+
+    public function __construct(string $abn)
+    {
+        $this->abn = $abn;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): CounterPartyDTO
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'counterPartyABN' => $this->abn,
+            ...($this->name
+                ? ['counterPartyName' => $this->name]
+                : [])
+        ];
+    }
+}

--- a/src/DTO/TransactionDTO.php
+++ b/src/DTO/TransactionDTO.php
@@ -29,6 +29,7 @@ class TransactionDTO implements JsonSerializable
     private ?InstallmentFrequency $installmentFrequency = null;
     private ?string $numberOfInstalments = null;
     private ?string $rateId = null;
+    private ?CounterPartyDTO $counterParty = null;
 
     public function getTransactionId(): string
     {
@@ -270,6 +271,18 @@ class TransactionDTO implements JsonSerializable
         return $this;
     }
 
+    public function setCounterParty(?CounterPartyDTO $counterParty): TransactionDTO
+    {
+        $this->counterParty = $counterParty;
+
+        return $this;
+    }
+
+    public function getCounterParty(): ?CounterPartyDTO
+    {
+        return $this->counterParty;
+    }
+
     public function jsonSerialize(): array
     {
         $data = [
@@ -332,6 +345,10 @@ class TransactionDTO implements JsonSerializable
 
         if ($this->getRateId()) {
             $data['rateId'] = $this->getRateId();
+        }
+
+        if ($this->getCounterParty()) {
+            $data['counterParty'] = $this->getCounterParty();
         }
 
         return $data;


### PR DESCRIPTION
Butn have requested that we add 2 fields to the transaction payload

The fields are below and reflect the company name and ABN for the Vendor/Carrier we are paying. This will assist in speeding up payments as well as making sure reporting is accurate.

`"counterParty": {
    "counterPartyName": "example 1",
    "counterPartyABN": "9898989XXXX"
}`


Relates to APP-2053